### PR TITLE
[Fix][Payment] 예치금 충전 코드 수정

### DIFF
--- a/Payment/src/main/java/co/kr/payment/client/UserClient.java
+++ b/Payment/src/main/java/co/kr/payment/client/UserClient.java
@@ -2,14 +2,16 @@ package co.kr.payment.client;
 
 import co.kr.payment.model.dto.request.BalanceClientReq;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "user-service", path = "/client/users" , url = "http://user-service:8080")
 public interface UserClient {
 
-    @PostMapping("/balance")
+    @PostMapping("/{userIdx}/balance")
     void updateBalance(
+            @PathVariable("userIdx") Long userIdx,
             @RequestBody BalanceClientReq request
     );
 }

--- a/Payment/src/main/java/co/kr/payment/controller/PaymentApiController.java
+++ b/Payment/src/main/java/co/kr/payment/controller/PaymentApiController.java
@@ -1,13 +1,15 @@
 package co.kr.payment.controller;
 
-import co.kr.payment.model.dto.request.ChargeReq;
+import co.kr.payment.model.dto.request.PaymentReq;
 import co.kr.payment.model.dto.request.RefundReq;
 import co.kr.payment.model.dto.response.PaymentResponse;
-import co.kr.payment.model.dto.request.PaymentReq;
 import co.kr.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,13 +30,6 @@ public class PaymentApiController {
             @RequestBody RefundReq request
     ) {
         return ResponseEntity.ok(paymentService.refund(request));
-    }
-
-    @PostMapping("/charge")
-    public ResponseEntity<PaymentResponse> charge(
-            @RequestBody ChargeReq request
-    ) {
-        return ResponseEntity.ok(paymentService.charge(request));
     }
 
 }

--- a/Payment/src/main/java/co/kr/payment/controller/PaymentController.java
+++ b/Payment/src/main/java/co/kr/payment/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package co.kr.payment.controller;
 
+import co.kr.payment.model.dto.request.ChargeReq;
 import co.kr.payment.model.dto.request.RefundReq;
 import co.kr.payment.model.dto.response.PaymentResponse;
 import co.kr.payment.service.PaymentService;
@@ -21,5 +22,13 @@ public class PaymentController {
     ) {
         RefundReq refundReq = new RefundReq(userIdx, request.orderCode());
         return ResponseEntity.ok(paymentService.refund(refundReq));
+    }
+
+    @PostMapping("/charge")
+    public ResponseEntity<PaymentResponse> charge(
+            @RequestHeader("X-USERS-IDX") Long userIdx,
+            @RequestBody ChargeReq request
+    ) {
+        return ResponseEntity.ok(paymentService.charge(userIdx, request));
     }
 }

--- a/Payment/src/main/java/co/kr/payment/model/dto/request/BalanceClientReq.java
+++ b/Payment/src/main/java/co/kr/payment/model/dto/request/BalanceClientReq.java
@@ -5,7 +5,6 @@ import co.kr.payment.model.vo.PaymentStatus;
 import java.math.BigDecimal;
 
 public record BalanceClientReq(
-        Long userIdx,
         PaymentStatus status,
         BigDecimal balance
 ) {

--- a/Payment/src/main/java/co/kr/payment/model/dto/request/ChargeReq.java
+++ b/Payment/src/main/java/co/kr/payment/model/dto/request/ChargeReq.java
@@ -8,9 +8,6 @@ import java.math.BigDecimal;
 
 public record ChargeReq(
 
-        @NotNull(message = "유저 인덱스는 필수입니다.")
-        Long userIdx,
-
         @NotNull(message = "충전 금액은 필수입니다.")
         @Positive(message = "충전 금액은 0보다 커야 합니다.")
         BigDecimal amount,

--- a/Payment/src/main/java/co/kr/payment/service/PaymentService.java
+++ b/Payment/src/main/java/co/kr/payment/service/PaymentService.java
@@ -10,5 +10,5 @@ public interface PaymentService {
 
     PaymentResponse refund(RefundReq refundRequest);
 
-    PaymentResponse charge(ChargeReq request);
+    PaymentResponse charge(Long userIdx, ChargeReq request);
 }


### PR DESCRIPTION
❗작업 사항
- 결제 서비스 예치금 충전 버그 수정
   - 원인: 충전 엔드포인트가 /client/ 경로로 설정되어 있어, 외부(프론트엔드)에서 접근이 제한됨
   - 해결: 엔드포인트를 /payments/charge로 변경하고 관련 비즈니스 로직 수정

- 순환 참조(Circular Dependency) 문제 해결
   - 원인: 결제 처리 중 Order 서비스와 FeignClient 통신 시, 서로를 다시 호출하는 구조가 발생하여 시스템 부하 및 오류 유발 (주문 상태 변경 로직 관련)
   - 해결: Order 서비스로 향하는 FeignClient 호출 코드를 제거하고 로직 구조 개선