### PR TITLE
[Fix][User] 서비스 간 연동 데이터(Seller IDX) 보완 및 공통 예외 응답 코드 정상화

### DIFF
--- a/User/build.gradle
+++ b/User/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'                          // JWT 페이로드 직렬화를 위한 Jackson 연동
 
     // --- [Cloud & Distributed Tracing (Microservices)] ---
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client' // 서비스 디스커버리(Eureka) 서버 등록/탐색
+//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client' // 서비스 디스커버리(Eureka) 서버 등록/탐색
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'                        // Micrometer와 Brave를 이용한 분산 트레이싱 가교
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'                            // 수집된 트레이스 정보를 Zipkin 서버로 전송
 

--- a/User/src/main/java/co/kr/user/exception/GlobalExceptionHandler.java
+++ b/User/src/main/java/co/kr/user/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package co.kr.user.exception;
 
 import co.kr.user.util.BaseResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -16,24 +17,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     /**
-     * 비즈니스 로직에서 발생하는 런타임 예외(IllegalArgumentException, IllegalStateException)를 처리합니다.
-     * 주로 잘못된 인자 전달이나 유효하지 않은 상태 접근 시 발생합니다.
+     * 비즈니스 로직에서 발생하는 런타임 예외를 처리합니다.
+     * 클라이언트의 잘못된 요청으로 인한 것이므로 HTTP 400 Bad Request를 반환합니다.
      *
      * @param e 발생한 런타임 예외
-     * @return 에러 메시지를 포함한 BaseResponse 객체 (HTTP 200 OK)
+     * @return 에러 메시지를 포함한 BaseResponse 객체 (HTTP 400 Bad Request)
      */
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public ResponseEntity<BaseResponse<String>> handleRuntimeException(RuntimeException e) {
-        // 예외 메시지를 그대로 응답 메시지로 사용하여 클라이언트에게 전달
-        return ResponseEntity.ok(new BaseResponse<>("FAIL", e.getMessage()));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new BaseResponse<>("FAIL", e.getMessage()));
     }
 
     /**
      * @Valid 어노테이션을 통한 유효성 검증 실패 시 발생하는 예외를 처리합니다.
-     * DTO의 필드 제약조건 위반 내용을 상세히 반환합니다.
+     * 입력값이 잘못된 것이므로 HTTP 400 Bad Request를 반환합니다.
      *
      * @param e 유효성 검증 예외
-     * @return 첫 번째 필드 에러 메시지를 포함한 BaseResponse 객체
+     * @return 첫 번째 필드 에러 메시지를 포함한 BaseResponse 객체 (HTTP 400 Bad Request)
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse<String>> handleValidationException(MethodArgumentNotValidException e) {
@@ -46,19 +46,20 @@ public class GlobalExceptionHandler {
             break; // 여러 에러가 있어도 하나만 표시하고 종료
         }
 
-        return ResponseEntity.ok(new BaseResponse<>("FAIL", errorMessage.toString()));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new BaseResponse<>("FAIL", errorMessage.toString()));
     }
 
     /**
      * 그 외 처리되지 않은 모든 일반적인 예외를 처리합니다.
+     * 서버 측의 예상치 못한 오류이므로 HTTP 500 Internal Server Error를 반환합니다.
      *
      * @param e 발생한 예외
-     * @return 서버 에러 메시지를 포함한 BaseResponse 객체
+     * @return 서버 에러 메시지를 포함한 BaseResponse 객체 (HTTP 500 Internal Server Error)
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<String>> handleException(Exception e) {
-        // 보안상 구체적인 에러 로그는 서버에만 남기고 클라이언트에는 일반적인 메시지 전달 가능
-        // 여기서는 예외 메시지를 그대로 반환하도록 설정됨
-        return ResponseEntity.ok(new BaseResponse<>("ERROR", e.getMessage()));
+        // 보안상 구체적인 에러 로그는 서버에만 남기고 클라이언트에는 일반적인 메시지 전달하는 것이 좋습니다.
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new BaseResponse<>("ERROR", "서버 내부 오류가 발생했습니다."));
+        // 기존처럼 원본 메시지를 보내려면 e.getMessage()를 사용하세요.
     }
 }

--- a/User/src/main/java/co/kr/user/model/dto/client/SellerBankDTO.java
+++ b/User/src/main/java/co/kr/user/model/dto/client/SellerBankDTO.java
@@ -9,6 +9,11 @@ import lombok.Data;
 public class SellerBankDTO {
 
     /**
+     * 판매자 고유 식별자 (UserIdx와 동일한 값)
+     */
+    private Long sellerIdx;
+
+    /**
      * 은행 브랜드 명칭 (예: 신한은행, 국민은행 등)
      */
     private String bankBrand;

--- a/User/src/main/java/co/kr/user/service/impl/ClientServiceImpl.java
+++ b/User/src/main/java/co/kr/user/service/impl/ClientServiceImpl.java
@@ -223,6 +223,7 @@ public class ClientServiceImpl implements ClientService {
         return sellers.stream()
                 .map(seller -> {
                     SellerBankDTO dto = new SellerBankDTO();
+                    dto.setSellerIdx(seller.getSellerIdx());
                     dto.setBankBrand(seller.getBankBrand());
                     dto.setBankName(seller.getBankName());
                     dto.setBankToken(seller.getBankToken());


### PR DESCRIPTION
## ❗작업 사항
  - 판매자 정보 DTO 확장: SellerBankDTO에 sellerIdx 필드를 추가하고, ClientServiceImpl에서 데이터를 담아 반환하도록 수정하여 서비스 간 데이터 무결성을 확보했습니다.
  - HTTP 상태 코드 정상화: GlobalExceptionHandler의 일반 예외 처리 메서드에서 응답 코드를 HttpStatus.INTERNAL_SERVER_ERROR(500)로 명시하여 표준 HTTP 규약을 준수하도록 수정했습니다.
  - Eureka 설정 비활성화: 현재 아키텍처에 맞춰 서비스 등록 관련 설정을 주석 처리하여 불필요한 네트워크 요청을 제거했습니다.